### PR TITLE
Center all hero tags

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -197,7 +197,7 @@ html {
   overflow: hidden;
   display: flex;
   align-items: center;
-  justify-content: flex-start;
+  justify-content: center;
   padding-left: 5%;
   box-sizing: border-box;
   border-bottom: 2px solid #333;
@@ -234,9 +234,6 @@ html {
   z-index: 1;
   transition: opacity 1s ease-in-out;
   opacity: 1;
-}
-.hero-header {
-    justify-content: center;
 }
 .hero-overlay {
   position: absolute;
@@ -950,6 +947,7 @@ footer {
       grid-template-columns: 1fr;
  }
 }
+
 
 
 

--- a/css/style.css
+++ b/css/style.css
@@ -235,6 +235,9 @@ html {
   transition: opacity 1s ease-in-out;
   opacity: 1;
 }
+.hero-header {
+    justify-content: center;
+}
 .hero-overlay {
   position: absolute;
   top: 0;
@@ -947,5 +950,6 @@ footer {
       grid-template-columns: 1fr;
  }
 }
+
 
 


### PR DESCRIPTION
Here is a video of me changing the "justify-content" flag. Do note that all references using this hero tag is all the banners on the wiki page, accepting this fork will justify all banners to be center.

High quality video: https://streamable.com/18v0ps

https://github.com/user-attachments/assets/0bb9f645-e1c9-4cd6-a770-adf6f2e19198

